### PR TITLE
fix: broken references between Project <-> JetBrainsIde

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -13,7 +13,7 @@ from xml.etree import ElementTree
 from albert import *
 
 md_iid = "5.0"
-md_version = "4.4.0"
+md_version = "4.4.1"
 md_name = "Jetbrains projects"
 md_description = "Open your JetBrains projects"
 md_license = "MIT"

--- a/__init__.py
+++ b/__init__.py
@@ -3,7 +3,6 @@
 # Copyright (c) 2018-2023 Thomas Queste
 # Copyright (c) 2023 Valentin Maerten
 
-from dataclasses import dataclass
 from pathlib import Path
 from time import time
 from typing import Union, List
@@ -21,6 +20,14 @@ md_url = "https://github.com/albertlauncher/albert-plugin-python-jetbrains-proje
 md_readme_url = "https://github.com/albertlauncher/albert-plugin-python-jetbrains-projects/blob/main/README.md"
 md_authors = ["@tomsquest", "@vmaerten", "@ManuelSchneid3r", "@d3v2a"]
 md_maintainers = ["@tomsquest", "@vmaerten", "@albi005"]
+
+
+class Project:
+    def __init__(self, name: str, path: str, last_opened: int, ide: 'JetBrainsIde'):
+        self.name = name
+        self.path = path
+        self.last_opened = last_opened
+        self.ide = ide
 
 
 class JetBrainsIde:
@@ -84,13 +91,6 @@ class JetBrainsIde:
                     return []
         return []
 
-
-@dataclass
-class Project:
-    name: str
-    path: str
-    last_opened: int
-    ide: JetBrainsIde
 
 
 def editors(icons_dir: Path) -> List[JetBrainsIde]:

--- a/__init__.py
+++ b/__init__.py
@@ -23,14 +23,6 @@ md_authors = ["@tomsquest", "@vmaerten", "@ManuelSchneid3r", "@d3v2a"]
 md_maintainers = ["@tomsquest", "@vmaerten", "@albi005"]
 
 
-@dataclass
-class Project:
-    name: str
-    path: str
-    last_opened: int
-    ide: JetBrainsIde
-
-
 class JetBrainsIde:
     name: str
     icon: Path
@@ -92,84 +84,92 @@ class JetBrainsIde:
                     return []
         return []
 
-    @staticmethod
-    def get_editors(icons_dir: Path) -> List[JetBrainsIde]:
-        editors = [
-            JetBrainsIde(
-                name="Android Studio",
-                icon=icons_dir / "androidstudio.svg",
-                config_dir_prefixes=["Google/AndroidStudio"],
-                binaries=["studio", "androidstudio", "android-studio", "android-studio-canary", "jdk-android-studio",
-                          "android-studio-system-jdk"]),
-            JetBrainsIde(
-                name="Aqua",
-                icon=icons_dir / "aqua.svg",
-                config_dir_prefixes=["JetBrains/Aqua"],
-                binaries=["aqua", "aqua-eap"]),
-            JetBrainsIde(
-                name="CLion",
-                icon=icons_dir / "clion.svg",
-                config_dir_prefixes=["JetBrains/CLion"],
-                binaries=["clion", "clion-eap"]),
-            JetBrainsIde(
-                name="DataGrip",
-                icon=icons_dir / "datagrip.svg",
-                config_dir_prefixes=["JetBrains/DataGrip"],
-                binaries=["datagrip", "datagrip-eap"]),
-            JetBrainsIde(
-                name="DataSpell",
-                icon=icons_dir / "dataspell.svg",
-                config_dir_prefixes=["JetBrains/DataSpell"],
-                binaries=["dataspell", "dataspell-eap"]),
-            JetBrainsIde(
-                name="GoLand",
-                icon=icons_dir / "goland.svg",
-                config_dir_prefixes=["JetBrains/GoLand"],
-                binaries=["goland", "goland-eap"]),
-            JetBrainsIde(
-                name="IntelliJ IDEA",
-                icon=icons_dir / "idea.svg",
-                config_dir_prefixes=["JetBrains/IntelliJIdea", "JetBrains/Idea"],
-                binaries=["idea", "idea.sh", "idea-ultimate", "idea-ce-eap", "idea-ue-eap", "intellij-idea-ce",
-                          "intellij-idea-ce-eap", "intellij-idea-ue-bundled-jre", "intellij-idea-ultimate-edition",
-                          "intellij-idea-community-edition-jre", "intellij-idea-community-edition-no-jre"]),
-            JetBrainsIde(
-                name="PhpStorm",
-                icon=icons_dir / "phpstorm.svg",
-                config_dir_prefixes=["JetBrains/PhpStorm"],
-                binaries=["phpstorm", "phpstorm-eap"]),
-            JetBrainsIde(
-                name="PyCharm",
-                icon=icons_dir / "pycharm.svg",
-                config_dir_prefixes=["JetBrains/PyCharm"],
-                binaries=["charm", "pycharm", "pycharm-eap", "pycharm-professional"]),
-            Rider(
-                name="Rider",
-                icon=icons_dir / "rider.svg",
-                config_dir_prefixes=["JetBrains/Rider"],
-                binaries=["rider", "rider-eap"]),
-            JetBrainsIde(
-                name="RubyMine",
-                icon=icons_dir / "rubymine.svg",
-                config_dir_prefixes=["JetBrains/RubyMine"],
-                binaries=["rubymine", "rubymine-eap", "jetbrains-rubymine", "jetbrains-rubymine-eap"]),
-            JetBrainsIde(
-                name="RustRover",
-                icon=icons_dir / "rustrover.svg",
-                config_dir_prefixes=["JetBrains/RustRover"],
-                binaries=["rustrover", "rustrover-eap"]),
-            JetBrainsIde(
-                name="WebStorm",
-                icon=icons_dir / "webstorm.svg",
-                config_dir_prefixes=["JetBrains/WebStorm"],
-                binaries=["webstorm", "webstorm-eap"]),
-            JetBrainsIde(
-                name="Writerside",
-                icon=icons_dir / "writerside.svg",
-                config_dir_prefixes=["JetBrains/Writerside"],
-                binaries=["writerside", "writerside-eap"]),
-        ]
-        return [e for e in editors if e.binary is not None]
+
+@dataclass
+class Project:
+    name: str
+    path: str
+    last_opened: int
+    ide: JetBrainsIde
+
+
+def editors(icons_dir: Path) -> List[JetBrainsIde]:
+    supported_editors = [
+        JetBrainsIde(
+            name="Android Studio",
+            icon=icons_dir / "androidstudio.svg",
+            config_dir_prefixes=["Google/AndroidStudio"],
+            binaries=["studio", "androidstudio", "android-studio", "android-studio-canary", "jdk-android-studio",
+                      "android-studio-system-jdk"]),
+        JetBrainsIde(
+            name="Aqua",
+            icon=icons_dir / "aqua.svg",
+            config_dir_prefixes=["JetBrains/Aqua"],
+            binaries=["aqua", "aqua-eap"]),
+        JetBrainsIde(
+            name="CLion",
+            icon=icons_dir / "clion.svg",
+            config_dir_prefixes=["JetBrains/CLion"],
+            binaries=["clion", "clion-eap"]),
+        JetBrainsIde(
+            name="DataGrip",
+            icon=icons_dir / "datagrip.svg",
+            config_dir_prefixes=["JetBrains/DataGrip"],
+            binaries=["datagrip", "datagrip-eap"]),
+        JetBrainsIde(
+            name="DataSpell",
+            icon=icons_dir / "dataspell.svg",
+            config_dir_prefixes=["JetBrains/DataSpell"],
+            binaries=["dataspell", "dataspell-eap"]),
+        JetBrainsIde(
+            name="GoLand",
+            icon=icons_dir / "goland.svg",
+            config_dir_prefixes=["JetBrains/GoLand"],
+            binaries=["goland", "goland-eap"]),
+        JetBrainsIde(
+            name="IntelliJ IDEA",
+            icon=icons_dir / "idea.svg",
+            config_dir_prefixes=["JetBrains/IntelliJIdea", "JetBrains/Idea"],
+            binaries=["idea", "idea.sh", "idea-ultimate", "idea-ce-eap", "idea-ue-eap", "intellij-idea-ce",
+                      "intellij-idea-ce-eap", "intellij-idea-ue-bundled-jre", "intellij-idea-ultimate-edition",
+                      "intellij-idea-community-edition-jre", "intellij-idea-community-edition-no-jre"]),
+        JetBrainsIde(
+            name="PhpStorm",
+            icon=icons_dir / "phpstorm.svg",
+            config_dir_prefixes=["JetBrains/PhpStorm"],
+            binaries=["phpstorm", "phpstorm-eap"]),
+        JetBrainsIde(
+            name="PyCharm",
+            icon=icons_dir / "pycharm.svg",
+            config_dir_prefixes=["JetBrains/PyCharm"],
+            binaries=["charm", "pycharm", "pycharm-eap", "pycharm-professional"]),
+        Rider(
+            name="Rider",
+            icon=icons_dir / "rider.svg",
+            config_dir_prefixes=["JetBrains/Rider"],
+            binaries=["rider", "rider-eap"]),
+        JetBrainsIde(
+            name="RubyMine",
+            icon=icons_dir / "rubymine.svg",
+            config_dir_prefixes=["JetBrains/RubyMine"],
+            binaries=["rubymine", "rubymine-eap", "jetbrains-rubymine", "jetbrains-rubymine-eap"]),
+        JetBrainsIde(
+            name="RustRover",
+            icon=icons_dir / "rustrover.svg",
+            config_dir_prefixes=["JetBrains/RustRover"],
+            binaries=["rustrover", "rustrover-eap"]),
+        JetBrainsIde(
+            name="WebStorm",
+            icon=icons_dir / "webstorm.svg",
+            config_dir_prefixes=["JetBrains/WebStorm"],
+            binaries=["webstorm", "webstorm-eap"]),
+        JetBrainsIde(
+            name="Writerside",
+            icon=icons_dir / "writerside.svg",
+            config_dir_prefixes=["JetBrains/Writerside"],
+            binaries=["writerside", "writerside-eap"]),
+    ]
+    return [e for e in supported_editors if e.binary is not None]
 
 
 class Rider(JetBrainsIde):
@@ -193,7 +193,7 @@ class Plugin(PluginInstance, GlobalQueryHandler):
         if self._match_path is None:
             self._match_path = False
         self.fuzzy = False
-        self.editors = JetBrainsIde.get_editors(Path(__file__).parent / "icons")
+        self.editors = editors(Path(__file__).parent / "icons")
         self.projects = []
         self.last_projects_update = 0
         self._update_projects()


### PR DESCRIPTION
Fix #8 

What I discovered:
- `Project` has to be first because it is used by `JetBrainsIde`
- `Project` is also referencing `JetBrainsIde`, so I changed the type to be a "forward reference string"
- `dataclass` was not working. Claude told me it's the module system of Albert, blabla. So a plain class will do.

Tested locally on Python 3.12